### PR TITLE
Remove redundant dependencies

### DIFF
--- a/storm-chronicle/pom.xml
+++ b/storm-chronicle/pom.xml
@@ -30,6 +30,64 @@
 			<groupId>storm</groupId>
 			<artifactId>storm</artifactId>
 			<version>0.7.2</version>
+			<exclusions>
+				<exclusion>
+				    <groupId>org.clojure</groupId>
+				    <artifactId>tools.cli</artifactId>
+				</exclusion>
+				<exclusion>
+				    <groupId>org.clojure</groupId>
+				    <artifactId>tools.logging</artifactId>
+				</exclusion>
+				<exclusion>
+				    <groupId>org.clojure</groupId>
+				    <artifactId>math.numeric-tower</artifactId>
+				</exclusion>
+				<exclusion>
+				    <groupId>hiccup</groupId>
+				    <artifactId>hiccup</artifactId>
+				</exclusion>
+				<exclusion>
+				    <groupId>ring</groupId>
+				    <artifactId>ring-servlet</artifactId>
+				</exclusion>
+				<exclusion>
+				    <groupId>org.clojure</groupId>
+				    <artifactId>core.incubator</artifactId>
+				</exclusion>
+				<exclusion>
+				    <groupId>org.clojure</groupId>
+				    <artifactId>tools.macro</artifactId>
+				</exclusion>
+				<exclusion>
+				    <groupId>clout</groupId>
+				    <artifactId>clout</artifactId>
+				</exclusion>
+				<exclusion>
+				    <groupId>javax.servlet</groupId>
+				    <artifactId>servlet-api</artifactId>
+				</exclusion>
+				<exclusion>
+				    <groupId>org.mortbay.jetty</groupId>
+				    <artifactId>servlet-api</artifactId>
+				</exclusion>
+				<exclusion>
+				    <groupId>ring</groupId>
+				    <artifactId>ring-core</artifactId>
+				</exclusion>
+				<exclusion>
+				    <groupId>compojure</groupId>
+				    <artifactId>compojure</artifactId>
+				</exclusion>
+				<exclusion>
+				    <groupId>clj-time</groupId>
+				    <artifactId>clj-time</artifactId>
+				</exclusion>
+				<exclusion>
+				    <groupId>ring</groupId>
+				    <artifactId>ring-jetty-adapter</artifactId>
+				</exclusion>
+            		</exclusions>
 		</dependency>
 	</dependencies>
 </project>


### PR DESCRIPTION
Hi, I am a user of project **_com.github.menacher:storm-chronicle:0.0.3-SNAPSHOT_**. I found that its pom file introduced **_47_** dependencies. However, among them, **_18_** libraries (**_38%_**) have not been used by your project (the redundant dependencies are listed below). Reduce these useless dependencies can help prevent conflicts between library versions. MeanWhile, it can minimize the total added size to projects. Finally, it can help enable advanced scenarios for users of your package. 
This PR helps **_com.github.menacher:storm-chronicle:0.0.3-SNAPSHOT_** lose weight :) I have tested the revised configuration in my local environment. It is safe to remove the unused libraries.

Best regards


## Redundant dependencies----
<pre><code>
org.clojure:tools.logging:jar:0.2.3:compile
hiccup:hiccup:jar:0.3.6:compile
ring:ring-jetty-adapter:jar:0.3.11:compile
clj-time:clj-time:jar:0.4.1:compile
ring:ring-servlet:jar:0.3.11:compile
joda-time:joda-time:jar:2.0:compile
org.mortbay.jetty:jetty-util:jar:6.1.26:compile
org.mortbay.jetty:servlet-api:jar:2.5-20081211:compile
commons-fileupload:commons-fileupload:jar:1.2.1:compile
clout:clout:jar:0.4.1:compile
org.clojure:tools.macro:jar:0.1.0:compile
org.clojure:core.incubator:jar:0.1.0:compile
org.mortbay.jetty:jetty:jar:6.1.26:compile
org.clojure:tools.cli:jar:0.2.1:compile
ring:ring-core:jar:0.3.10:compile
javax.servlet:servlet-api:jar:2.5:compile
compojure:compojure:jar:0.6.4:compile
org.clojure:math.numeric-tower:jar:0.0.1:compile
</code></pre>
## Vulnerable libraries
commons-fileupload:commons-fileupload:1.2.1 (CVE-2014-0050)

## Outdated dependencies
org.clojure:core.incubator:0.1.0 (**_4469_** days without maintenance)
commons-fileupload:commons-fileupload:1.2.1 (**_5647_** days without maintenance)
org.mortbay.jetty:jetty:6.1.26 (**_4643_** days without maintenance)
org.clojure:tools.cli:0.2.1 (**_4285_** days without maintenance)
org.clojure:tools.logging:0.2.3 (**_4320_** days without maintenance)
joda-time:joda-time:2.0 (**_4380_** days without maintenance)
org.mortbay.jetty:servlet-api:2.5-20081211 (**_5342_** days without maintenance)
org.mortbay.jetty:jetty-util:6.1.26 (**_4643_** days without maintenance)